### PR TITLE
handle duplicate elements in stringTable

### DIFF
--- a/EtwExplorer/ViewModels/MainViewModel.cs
+++ b/EtwExplorer/ViewModels/MainViewModel.cs
@@ -95,13 +95,13 @@ namespace EtwExplorer.ViewModels {
 					DoOpenXml(xml);
 					Keywords = null;
 				}
-				catch (Exception) {
+				catch (Exception e) {
 					var keywords = TraceEventProviders.GetProviderKeywords(vm.SelectedProvider.Guid).Select(info => new EtwKeyword {
 						Name = info.Name,
 						Mask = info.Value,
 						Message = info.Description
 					}).ToArray();
-					UI.MessageBoxService.ShowMessage("Full event information is not available. Showing keywords only.", Constants.AppTitle, MessageBoxButton.OK, MessageBoxImage.Warning);
+					UI.MessageBoxService.ShowMessage($"{e.Message}\nShowing keywords only.", Constants.AppTitle, MessageBoxButton.OK, MessageBoxImage.Warning);
 
 					if (vm.CloseCurrentManifest) {
 						DoClose();

--- a/EtwManifestParsing/ManifestParser.cs
+++ b/EtwManifestParsing/ManifestParser.cs
@@ -16,7 +16,7 @@ namespace EtwManifestParsing {
 				if (stringTable != null) {
 					var strings = stringTable.DescendantNodes().OfType<XElement>().ToArray();
 					var table = new Dictionary<string, string>(strings.Length);
-					Array.ForEach(strings, node => table.Add((string)node.Attribute("id"), (string)node.Attribute("value")));
+					Array.ForEach(strings, node => { try { table.Add((string)node.Attribute("id"), (string)node.Attribute("value")); } catch { } });
 					manifest.StringTable = table;
 				}
 


### PR DESCRIPTION
The stringTable returned by GetManifestForRegisteredProvider() can include duplicate elements.  (Reported upstream at https://github.com/microsoft/perfview/issues/1069).  This causes some providers (e.g. Microsoft-JScript) to not parse correctly.

Also changed the manifest parsing exception messagebox to highlight the difference between an XML parsing failure (e.g. Microsoft-JScript) and no manifest available (e.g. ADODB.1).