### PR TITLE
add support for MOF providers

### DIFF
--- a/EtwExplorer/EtwExplorer.csproj
+++ b/EtwExplorer/EtwExplorer.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.36\build\Microsoft.Diagnostics.Tracing.TraceEvent.props" Condition="Exists('..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.36\build\Microsoft.Diagnostics.Tracing.TraceEvent.props')" />
+  <Import Project="..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.48\build\Microsoft.Diagnostics.Tracing.TraceEvent.props" Condition="Exists('..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.48\build\Microsoft.Diagnostics.Tracing.TraceEvent.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -46,20 +46,20 @@
       <HintPath>..\packages\ControlzEx.3.0.2.4\lib\net462\ControlzEx.dll</HintPath>
     </Reference>
     <Reference Include="Dia2Lib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.36\lib\net45\Dia2Lib.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.48\lib\net45\Dia2Lib.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="MahApps.Metro, Version=1.6.5.1, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MahApps.Metro.1.6.5\lib\net47\MahApps.Metro.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.FastSerialization, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.36\lib\net45\Microsoft.Diagnostics.FastSerialization.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.48\lib\net45\Microsoft.Diagnostics.FastSerialization.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.36\lib\net45\Microsoft.Diagnostics.Tracing.TraceEvent.dll</HintPath>
+    <Reference Include="Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.48.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.48\lib\net45\Microsoft.Diagnostics.Tracing.TraceEvent.dll</HintPath>
     </Reference>
     <Reference Include="OSExtensions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.36\lib\net45\OSExtensions.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.48\lib\net45\OSExtensions.dll</HintPath>
     </Reference>
     <Reference Include="Prism, Version=6.3.0.0, Culture=neutral, PublicKeyToken=40ee6c3a2184dc59, processorArchitecture=MSIL">
       <HintPath>..\packages\Prism.Core.6.3.0\lib\net45\Prism.dll</HintPath>
@@ -80,7 +80,7 @@
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
     <Reference Include="TraceReloggerLib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.36\lib\net45\TraceReloggerLib.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.48\lib\net45\TraceReloggerLib.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="WindowsBase" />
@@ -219,6 +219,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.36\build\Microsoft.Diagnostics.Tracing.TraceEvent.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.36\build\Microsoft.Diagnostics.Tracing.TraceEvent.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.48\build\Microsoft.Diagnostics.Tracing.TraceEvent.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.48\build\Microsoft.Diagnostics.Tracing.TraceEvent.props'))" />
   </Target>
 </Project>

--- a/EtwExplorer/packages.config
+++ b/EtwExplorer/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="ControlzEx" version="3.0.2.4" targetFramework="net472" />
   <package id="MahApps.Metro" version="1.6.5" targetFramework="net472" />
-  <package id="Microsoft.Diagnostics.Tracing.TraceEvent" version="2.0.36" targetFramework="net472" />
+  <package id="Microsoft.Diagnostics.Tracing.TraceEvent" version="2.0.48" targetFramework="net472" />
   <package id="Prism.Core" version="6.3.0" targetFramework="net472" />
   <package id="Zodiacon.WPF" version="1.2.17" targetFramework="net472" />
 </packages>

--- a/EtwManifestParsing/EtwManifestParsing.csproj
+++ b/EtwManifestParsing/EtwManifestParsing.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.48\build\Microsoft.Diagnostics.Tracing.TraceEvent.props" Condition="Exists('..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.48\build\Microsoft.Diagnostics.Tracing.TraceEvent.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -11,6 +12,8 @@
     <AssemblyName>EtwManifestParsing</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,14 +33,32 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Dia2Lib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.48\lib\net45\Dia2Lib.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="Microsoft.Diagnostics.FastSerialization, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.48\lib\net45\Microsoft.Diagnostics.FastSerialization.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.48.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.48\lib\net45\Microsoft.Diagnostics.Tracing.TraceEvent.dll</HintPath>
+    </Reference>
+    <Reference Include="OSExtensions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.48\lib\net45\OSExtensions.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Management" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="TraceReloggerLib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.48\lib\net45\TraceReloggerLib.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EtwEvent.cs" />
@@ -48,5 +69,14 @@
     <Compile Include="EtwTemplate.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.48\build\Microsoft.Diagnostics.Tracing.TraceEvent.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.2.0.48\build\Microsoft.Diagnostics.Tracing.TraceEvent.props'))" />
+  </Target>
 </Project>

--- a/EtwManifestParsing/EtwTemplate.cs
+++ b/EtwManifestParsing/EtwTemplate.cs
@@ -23,6 +23,12 @@ namespace EtwManifestParsing {
 			}).ToArray();
 		}
 
+		internal EtwTemplate(string id, EtwTemplateData[] items)
+		{
+			Id = id;
+			Items = items;
+		}
+
 		public override string ToString() => $"{Id} {Items.Length} template items";
 	}
 }

--- a/EtwManifestParsing/ManifestParser.cs
+++ b/EtwManifestParsing/ManifestParser.cs
@@ -1,7 +1,11 @@
-﻿using System;
+﻿using Microsoft.Diagnostics.Tracing.Session;
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Management;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 
@@ -80,5 +84,254 @@ namespace EtwManifestParsing {
 			return Parse(XElement.Parse(xml));
 		}
 
-	}
+        public static EtwManifest ParseWmiEventTraceClass(Guid provider) {
+            // we make a best effort attempt to fit the metadata of this Legacy (MOF) provider into the instrumentation manifest format
+
+            // we need to find the EventTrace class where the Guid class qualifier matches our provider Guid
+            // afaik you can't query for qualifiers...just classes and properties.  :-/
+            // so we loop through all of the EventTrace classes and compare
+            var providerSearcher = new ManagementObjectSearcher("root\\WMI", $"SELECT * FROM meta_class WHERE __superclass = 'EventTrace'", null);
+            ManagementClass providerClass = null;
+            foreach (ManagementClass candidateProviderClass in providerSearcher.Get()) {
+                foreach (QualifierData qd in candidateProviderClass.Qualifiers) {
+                    if (qd.Name.ToLower() == "guid" && new Guid((string)qd.Value) == provider) {
+                        providerClass = candidateProviderClass;
+                        break; // found
+                    }
+                }
+
+                if (providerClass != null)
+                    break; // found
+            }
+
+            if (providerClass == null) // not found
+                throw new ApplicationException($"Provider {provider} has no corresponding EventTrace class in WMI Repository");
+
+            var mof = ToMofString(providerClass);
+
+            var manifest = new EtwManifest(mof)
+            {
+                ProviderGuid = provider,
+                ProviderSymbol = (string)providerClass["__CLASS"]
+            };
+
+            var events = new SortedDictionary<string, EtwEvent>();
+            var templates = new List<EtwTemplate>();
+            var stringTable = new Dictionary<string, string>();
+
+            // the provider name is usually in the Description Qualifier for the EventTrace class (but not always?)
+            // and the keywords are properties for the EventTrace class
+            // but we can already get both of these easily from Microsoft.Diagnostics.Tracing
+            manifest.ProviderName = TraceEventProviders.GetProviderName(provider);
+            manifest.Keywords = TraceEventProviders.GetProviderKeywords(provider).Select(info => new EtwKeyword
+            {
+                Name = info.Name,
+                Mask = info.Value,
+                Message = info.Description
+            }).ToArray();
+
+            // event details are in the grandchildren of the top-level (EventTrace) provider class
+            // WMI EventTrace children ~ a versioned category grouping
+            // WMI EventTrace grandchildren ~ instrumentation manifest templates
+            // note - event version can be set on the category and/or the event
+            var templateNames = new SortedSet<string>();
+            var taskSearcher = new ManagementObjectSearcher("root\\WMI", $"SELECT * FROM meta_class WHERE __superclass = '{providerClass["__CLASS"]}'", null);
+            foreach (ManagementClass categoryVersionClass in taskSearcher.Get())
+            {
+                var categoryVersion = 0;
+                var category = string.Empty;
+                var description = string.Empty;
+                var displayName = string.Empty;
+                foreach (QualifierData qd in categoryVersionClass.Qualifiers) {
+                    if (qd.Value.GetType() == typeof(Int32) && qd.Name.ToLower() == "eventversion")
+                        categoryVersion = (Int32)qd.Value;
+                    else if (qd.Value.GetType() == typeof(String) && qd.Name.ToLower() == "guid")
+                        category = (string)qd.Value;
+                    else if (qd.Value.GetType() == typeof(String) && qd.Name.ToLower() == "description")
+                        description = (string)qd.Value;
+                    else if (qd.Value.GetType() == typeof(String) && qd.Name.ToLower() == "displayname")
+                        displayName = (string)qd.Value;
+                }
+
+                if (!string.IsNullOrEmpty(description))
+                    stringTable.Add(!string.IsNullOrEmpty(displayName) ? displayName : (string)categoryVersionClass["__CLASS"], description);
+
+                var templateSearcher = new ManagementObjectSearcher("root\\WMI", $"SELECT * FROM meta_class WHERE __superclass = '{categoryVersionClass["__CLASS"]}'", null);
+                foreach (ManagementClass templateClass in templateSearcher.Get()) {
+                    // EventTypeName qualifier ~ OpCode
+                    var template = (string)templateClass["__CLASS"];
+                    var eventType = string.Empty;
+                    var version = categoryVersion;
+                    description = string.Empty;
+                    foreach (QualifierData qd in templateClass.Qualifiers) {
+                        if (qd.Value.GetType() == typeof(Int32) && qd.Name.ToLower() == "eventversion")
+                            version = (Int32)qd.Value; // override category version with specific event version
+                        else if (qd.Value.GetType() == typeof(String) && qd.Name.ToLower() == "eventtypename")
+                            eventType = (string)qd.Value;
+                        else if (qd.Value.GetType() == typeof(String) && qd.Name.ToLower() == "description")
+                            description = (string)qd.Value;
+                    }
+                    if (!string.IsNullOrEmpty(description))
+                        stringTable.Add(template, description);
+
+                    // EventType -> id(s)
+                    var ids = new SortedSet<Int32>();
+                    foreach (QualifierData qd in templateClass.Qualifiers) {
+                        if (qd.Name.ToLower() == "eventtype") {
+                            if (qd.Value.GetType() == typeof(Int32))
+                                ids.Add((Int32)qd.Value);
+                            else if (qd.Value.GetType().IsArray) {
+                                foreach (var element in (Array)qd.Value) {
+                                    if (element.GetType() == typeof(Int32))
+                                        ids.Add((Int32)element);
+                                }
+                            }
+                            break;
+                        }
+                    }
+
+                    // sort by category, id, version
+                    foreach (var id in ids)
+                    {
+                        events.Add($"{category}{id,6}{version,6}",
+                            new EtwEvent
+                            {
+                                Value = id,
+                                Symbol = template,
+                                Opcode = eventType,
+                                Version = version,
+                                Template = template,
+                                Keyword = string.Empty,
+                                Task = category
+                            });
+                    }
+
+                    // create a template from the properties
+                    var templateData = new SortedDictionary<int, EtwTemplateData>();
+                    foreach (PropertyData pd in templateClass.Properties) {
+                        foreach (QualifierData qd in pd.Qualifiers) {
+                            if (qd.Value.GetType() == typeof(Int32) && qd.Name.ToLower() == "wmidataid") {
+                                var id = (int)qd.Value;
+                                templateData[id] = new EtwTemplateData
+                                {
+                                    Name = pd.Name,
+                                    Type = pd.Type.ToString()
+                                };
+                                break;
+                            }
+                        }
+                    }
+
+                    templates.Add(new EtwTemplate(template, templateData.Values.ToArray()));
+                }
+            }
+
+            manifest.Events = events.Values.ToArray();
+            manifest.Templates = templates.ToArray();
+            manifest.StringTable = stringTable;
+
+            return manifest;
+        }
+
+        static string ToMofString(ManagementClass wmiClass)
+        {
+            var mofString = string.Empty;
+
+            // print the (qualified) class name, and then all of the (qualified) properties
+            mofString += ToMofString(wmiClass.Qualifiers, string.Empty, "\n");
+            mofString += $"class {wmiClass["__CLASS"]} : {wmiClass["__SUPERCLASS"]}\n";
+            mofString += "{\n";
+
+            var orderedProperties = new SortedDictionary<int, string>();
+            foreach (PropertyData pd in wmiClass.Properties) {
+                if (!pd.IsLocal)
+                    continue;
+                // sort properties according to the WmiDataId qualifer (if available)
+                var propertyString = $"\t{ToMofString(pd.Qualifiers, "\t", " ")}{pd.Type.ToString().ToLower()} {pd.Name};\n";
+                var propertyMatch = new Regex(@"wmidataid\((?<WmiDataId>\d+)\)", RegexOptions.IgnoreCase).Match(propertyString);
+                if (propertyMatch.Success)
+                    orderedProperties[Convert.ToInt32(propertyMatch.Groups["WmiDataId"].Value)] = propertyString;
+                else
+                    mofString += propertyString;
+            }
+
+            foreach (var propertyString in orderedProperties.Values) {
+                mofString += propertyString;
+            }
+
+            mofString += "};\n\n";
+
+            // event details are in descendant classes of the top-level (EventTrace) provider class
+            // so also enumerate all of the children on this class
+            var providerSearcher = new ManagementObjectSearcher("root\\WMI", $"SELECT * FROM meta_class WHERE __superclass = '{wmiClass["__CLASS"]}'", null);
+            foreach (ManagementClass providerClass in providerSearcher.Get()) {
+                mofString += ToMofString(providerClass);
+            }
+
+            return mofString;
+        }
+
+        // based on the mof representation of wbemtest
+        internal static string[] qualifierOrder = { "wmidataid(", "dynamic", "description(", "guid(", "displayname(", "displaynames(", "eventtype(", "eventtype{", "eventtypename(", "eventtypename{", "eventversion(", "valuedescriptions{", "definevalues{", "values{", "valuemap{", "valuetype(", "extension(", "activityid", "relatedactivityid", "stringtermination(", "format(", "wmisizeis(", "xmlfragment", "pointer", "read", "max", "locale(" };
+
+        static string ToMofString(QualifierDataCollection qualifiers, string prefix, string suffix)
+        {
+            var qualifierString = string.Empty;
+
+            var qualifierList = new List<string>();
+            var maxQualifierLength = 0;
+
+            foreach (QualifierData qualifier in qualifiers) {
+                if (qualifier.Name == "CIMTYPE")
+                    continue;
+
+                var strQualifier = qualifier.Name;
+                if (qualifier.Value.GetType() == typeof(String))
+                    strQualifier += $"(\"{qualifier.Value}\")";
+                else if (qualifier.Value.GetType() == typeof(Int32))
+                    strQualifier += $"({qualifier.Value})";
+                else if (qualifier.Value.GetType() == typeof(Boolean))
+                { } // add nothing
+                else if (qualifier.Value.GetType().IsArray) {
+                    var qualifierValueList = new List<string>();
+                    foreach (var element in (Array)qualifier.Value)
+                        qualifierValueList.Add(element.GetType() == typeof(String) ? $"\"{element}\"" : $"{element}");
+                    strQualifier += $"{{{string.Join(", ", qualifierValueList)}}}";
+                }
+                else
+                    throw new ApplicationException($"Unsupported Qualifier Type - {qualifier.Value.GetType().Name}");
+
+                if (qualifier.PropagatesToInstance)
+                    strQualifier += ": ToInstance";
+
+                maxQualifierLength = strQualifier.Length > maxQualifierLength ? strQualifier.Length : maxQualifierLength;
+                qualifierList.Add(strQualifier);
+            }
+
+            var orderedQualifierList = new List<string>();
+            foreach (var nextQualifierInOrder in qualifierOrder) {
+                var foundQualifier = string.Empty;
+                foreach (var qualifier in qualifierList) {
+                    if (qualifier.ToLower().StartsWith(nextQualifierInOrder)) {
+                        orderedQualifierList.Add(qualifier);
+                        continue;
+                    }
+                }
+            }
+
+            if (qualifierList.Count != orderedQualifierList.Count)
+                throw new ApplicationException($"Unknown Qualifier Type(s) - {String.Join(",", qualifierList.ToArray())}");
+
+            if (orderedQualifierList.Count > 0) {
+                var wrapQualifiers = maxQualifierLength > 80;
+                var header = "[";
+                var delimiter = wrapQualifiers ? $",\n{prefix} " : ", ";
+                var footer = wrapQualifiers ? $"\n{prefix}]{suffix}" : $"]{suffix}";
+
+                qualifierString = $"{header}{string.Join(delimiter, orderedQualifierList)}{footer}";
+            }
+
+            return qualifierString;
+        }
+    }
 }

--- a/EtwManifestParsing/packages.config
+++ b/EtwManifestParsing/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Diagnostics.Tracing.TraceEvent" version="2.0.48" targetFramework="net461" />
+</packages>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # EtwExplorer
-View ETW Provider manifest
+View ETW Provider metadata
 
-Event Tracing for Windows (ETW) is a logging facility built into the Windows OS. Registered providers have a manifest that describes all the events they support, with their properties.
+Event Tracing for Windows ([ETW](https://docs.microsoft.com/en-us/windows/win32/etw/event-metadata-overview)) is a logging facility built into the Windows OS. Modern providers register a manifest that describes all the events they support, with their properties. Classic providers register a MOF instead.
 
 ETW Explorer attempts to show these events with a simple GUI.
 
-![ETWExplorer](https://github.com/zodiacon/EtwExplorer/blob/master/etwexplorer2.PNG)
+![ETWExplorer](./etwexplorer2.PNG)


### PR DESCRIPTION
If an instrumentation manifest is not available, then search for a matching WMI EventTrace class and enumerate the metadata there. The mapping of fields isn't perfect - but it was quicker than an alternate UI.

"Windows Kernel Trace" and "Active Directory Domain Services: SAM" are two good examples.

Some providers seem to have neither a manifest or a mof definition.  e.g. Microsoft-Antimalware-ShieldProvider